### PR TITLE
Add option to upload Docker directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,15 @@ SSH key must be in PEM format (begins with -----BEGIN RSA PRIVATE KEY-----)
 
 The SSH port to be used. Default is 22.
 
-### `stack_file_name`
+### `compose_file_name`
 
-Docker stack file used. Default is docker-compose.yml
+Docker compose file used. Default is docker-compose.yml, for example when it's inside a sub-directory `caddy/docker-compose.yml`
+
+### `upload_directory`
+Uploads docker compose directory, useful when extra files like Configs are needed for the compose project.
+
+### `docker_compose_directory`
+Specifies which directory in the repository to upload, needed for upload_directory
 
 ### `docker_login_user`
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ SSH key must be in PEM format (begins with -----BEGIN RSA PRIVATE KEY-----)
 
 The SSH port to be used. Default is 22.
 
-### `compose_file_name`
+### `compose_file_path`
 
-Docker compose file used. Default is docker-compose.yml, for example when it's inside a sub-directory `caddy/docker-compose.yml`
+path for Docker compose file used. Default is `docker-compose.yml`(repo root), for example when it's inside a sub-directory `caddy/docker-compose.yml`
 
 ### `upload_directory`
 Uploads docker compose directory, useful when extra files like Configs are needed for the compose project.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,12 @@ inputs:
   ssh_port:
     description: The ssh port of the server. Default is 22
     required: false
+  upload_directory:
+    description: when enabled, uploads entire docker directory, useful for configuration files needed along the container
+    default: 'false'
+  docker_compose_directory:
+    description: specifies which directory to upload, needed for upload_directory
+    required: false
   docker_login_password:
     description: The docker login password
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
   args:
     description: Deployment command args.
     required: true
-  compose_file_name:
-    description: Docker compose file used. Default is docker-compose.yaml
+  compose_file_path:
+    description: path for Docker compose file used. Default is is repo root(docker-compose.yml)
     required: false
   ssh_port:
     description: The ssh port of the server. Default is 22

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,7 +85,7 @@ then
       echo "Input docker_compose_directory is required when upload_directory is enabled!"
       exit 1
     fi
-    tar cjvf - -C "$GITHUB_ACTION_PATH" "$INPUT_DOCKER_COMPOSE_DIRECTORY" | ssh -o StrictHostKeyChecking=no "$SSH_HOST" 'tar -xjvf -'
+    tar cjvf - -C "$GITHUB_WORKSPACE" "$INPUT_DOCKER_COMPOSE_DIRECTORY" | ssh -o StrictHostKeyChecking=no "$SSH_HOST" 'tar -xjvf -'
 fi
 
 if  [ -n "$INPUT_DOCKER_LOGIN_PASSWORD" ] || [ -n "$INPUT_DOCKER_LOGIN_USER" ] || [ -n "$INPUT_DOCKER_LOGIN_REGISTRY" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,15 +35,15 @@ if [ -z "$INPUT_ARGS" ]; then
   exit 1
 fi
 
-if [ -z "$INPUT_COMPOSE_FILE_NAME" ]; then
-  INPUT_COMPOSE_FILE_NAME=docker-compose.yml
+if [ -z "$INPUT_COMPOSE_FILE_PATH" ]; then
+  INPUT_COMPOSE_FILE_PATH=docker-compose.yml
 fi
 
 if [ -z "$INPUT_SSH_PORT" ]; then
   INPUT_SSH_PORT=22
 fi
 
-COMPOSE_FILE=${INPUT_COMPOSE_FILE_NAME}
+COMPOSE_FILE=${INPUT_COMPOSE_FILE_PATH}
 DOCKER_HOST=ssh://${INPUT_REMOTE_DOCKER_HOST}:${INPUT_SSH_PORT}
 DEPLOYMENT_COMMAND="docker compose -f $COMPOSE_FILE"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,7 +85,8 @@ then
       echo "Input docker_compose_directory is required when upload_directory is enabled!"
       exit 1
     fi
-    tar cjvf - -C "$GITHUB_WORKSPACE" "$INPUT_DOCKER_COMPOSE_DIRECTORY" | ssh -o StrictHostKeyChecking=no "$SSH_HOST" 'tar -xjvf -'
+    tar cjvf - -C "$GITHUB_WORKSPACE" "$INPUT_DOCKER_COMPOSE_DIRECTORY" | ssh -o StrictHostKeyChecking=no "$INPUT_REMOTE_DOCKER_HOST" 'tar -xjvf -'
+    echo "Upload finished"
 fi
 
 if  [ -n "$INPUT_DOCKER_LOGIN_PASSWORD" ] || [ -n "$INPUT_DOCKER_LOGIN_USER" ] || [ -n "$INPUT_DOCKER_LOGIN_REGISTRY" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -77,6 +77,16 @@ echo "Create docker context"
 docker context create staging --docker "host=ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_SSH_PORT"
 docker context use staging
 
+if $INPUT_UPLOAD_DIRECTORY
+then
+    echo "upload_directory enabled"
+    if [ -z "$INPUT_DOCKER_COMPOSE_DIRECTORY" ]; 
+    then
+      echo "Input docker_compose_directory is required when upload_directory is enabled!"
+      exit 1
+    fi
+    tar cjvf - -C "$GITHUB_ACTION_PATH" "$INPUT_DOCKER_COMPOSE_DIRECTORY" | ssh -o StrictHostKeyChecking=no "$SSH_HOST" 'tar -xjvf -'
+fi
 
 if  [ -n "$INPUT_DOCKER_LOGIN_PASSWORD" ] || [ -n "$INPUT_DOCKER_LOGIN_USER" ] || [ -n "$INPUT_DOCKER_LOGIN_REGISTRY" ]; then
   echo "Connecting to $INPUT_REMOTE_DOCKER_HOST... Command: docker login"


### PR DESCRIPTION
This PR adds the ability to upload the projects' directory, which is helpful when there are configuration files needed.

## Changes

- add upload_directory and docker_compose_directory
- compose_file_name >>compose_file_path, so it's more clear that a file can be inside a sub-directory